### PR TITLE
Re-export the Error enum 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod sign;
 mod util;
 mod verify;
 
-pub use {sign::*, util::*, verify::*};
+pub use {sign::*, util::*, verify::*, error::Error};
 
 type Result<T = (), E = Error> = std::result::Result<T, E>;
 


### PR DESCRIPTION
Re-export the `Error` enum so it can be used in error matching